### PR TITLE
Update tls_server.py

### DIFF
--- a/src/tls_server.py
+++ b/src/tls_server.py
@@ -4,7 +4,7 @@ import os
 
 # --- Configuration ---
 HOST_IP = '0.0.0.0'
-PORT = 4443
+PORT = 443
 CERT_DIR = '/certs'
 CERT_FILE = os.path.join(CERT_DIR, 'homelan.pem')
 KEY_FILE = os.path.join(CERT_DIR, 'homelan.key')


### PR DESCRIPTION
requires port 443, must run on 443 - will not detect on other ports

### Description

Please provide a clear description of the changes in this pull request. What problem does it solve?

---

### Checklist

*Before submitting this PR, please make sure you have completed the following:*

- [ ] I have tested my changes locally and they work as expected.
- [ ] My code follows the project's style guidelines.
- [ ] I have updated the `README.md` with any necessary changes to the documentation.

